### PR TITLE
Adding basic structure for rest package

### DIFF
--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,0 +1,30 @@
+// Package rest provides functionality to handle
+// the HTTP interactions with the Azure API.
+package rest
+
+// Post performs a POST HTTP request to the Azure API to create the provided resource.
+// It returns the created resource as a byte array and any errors encountered.
+func Post(resource []byte) ([]byte, error) {
+	return []byte(""), nil
+}
+
+// Get performs a GET HTTP request to the Azure API to read the resource
+// identified by the provided resource ID.
+// It returns the requested resource as a byte array and any errors encountered.
+func Get(id string) ([]byte, error) {
+	return []byte(""), nil
+}
+
+// Put performs a PUT HTTP request to the Azure API for the provided
+// resource ID to replace the existing remote resource with the provided resource.
+// It returns the updated resource as a byte array and any errors encountered.
+func Put(id string, resource []byte) ([]byte, error) {
+	return []byte(""), nil
+}
+
+// Delete performs a DELETE HTTP request to the Azure API to remove the resource
+// identified by the provided resource ID.
+// It returns any errors encountered.
+func Delete(id string) error {
+	return nil
+}

--- a/rest/rest_suite_test.go
+++ b/rest/rest_suite_test.go
@@ -1,0 +1,13 @@
+package rest_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Rest Suite")
+}

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -1,0 +1,49 @@
+package rest_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "cosmos-go-sdk/rest"
+)
+
+var _ = Describe("Rest", func() {
+	var resource []byte
+	var id string
+
+	BeforeEach(func() {
+		resource = []byte("This is a test resource")
+		id = "1"
+	})
+
+	Context("Post", func() {
+		It("should successfully POST a resource in Azure", func() {
+			testPostResource, testPostError := Post(resource)
+			Expect(testPostResource).To(Not(BeNil()))
+			Expect(testPostError).To(BeNil())
+		})
+	})
+
+	Context("Get", func() {
+		It("should successfully GET a resource from Azure", func() {
+			testGetResource, testGetError := Get(id)
+			Expect(testGetResource).To(Not(BeNil()))
+			Expect(testGetError).To(BeNil())
+		})
+	})
+
+	Context("Put", func() {
+		It("should successfully PUT a resource in Azure", func() {
+			testPutResource, testPutError := Put(id, resource)
+			Expect(testPutResource).To(Not(BeNil()))
+			Expect(testPutError).To(BeNil())
+		})
+	})
+
+	Context("Delete", func() {
+		It("should successfully DELETE a resource in Azure", func() {
+			testDeleteError := Delete(id)
+			Expect(testDeleteError).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
Added basic structure for rest package including unit tests, so developers can contribute to a similar base in parallel. 