### PR TITLE
Adding Document Create Function

### DIFF
--- a/document/document.go
+++ b/document/document.go
@@ -12,6 +12,14 @@ type Document struct {
 	Request      rest.IRequest
 }
 
+// IDocument is the interface that defines the functionality of the document package
+type IDocument interface {
+	Read() ([]byte, error)
+	Create(doc []byte) ([]byte, error)
+	Update(doc []byte) ([]byte, error)
+	Delete() error
+}
+
 // New returns an instance of the document struct.
 func New(id, partitionKey, containerURI, key string) Document {
 	// TODO: [NS] Create util function for building URI
@@ -25,13 +33,14 @@ func New(id, partitionKey, containerURI, key string) Document {
 	}
 }
 
-// TODO: Consider all SQL Queries are creates
-// TODO: Separate HTTP request to utils
-
-// Create creates an document in the Azure Cosmos Database Container.
+// Create creates a document in the Azure Cosmos Database Container.
 // It returns any errors encountered.
-func (document Document) Create(doc []byte) error {
-	return nil
+func (document Document) Create(doc []byte) ([]byte, error) {
+	doc, err := document.Request.Post(doc)
+	if err != nil {
+		return nil, err
+	}
+	return doc, nil
 }
 
 // Read reads a document in the Azure Cosmos Database Container.

--- a/document/document_test.go
+++ b/document/document_test.go
@@ -54,9 +54,11 @@ var _ = Describe("document", func() {
 
 	Context("Create", func() {
 		It("should successfully create a document in the Azure Cosmos Database Container", func() {
-			testDocument := []byte("This is a test new document")
-			testCreateError := testdocument.Create(testDocument)
+			testDocument := []byte("This is a test created document")
+			mockRequest.EXPECT().Post(testDocument).Return([]byte("This is a test created document that was created"), nil).Times(1)
+			createdDocument, testCreateError := testdocument.Create(testDocument)
 			Expect(testCreateError).To(BeNil())
+			Expect(createdDocument).To(Equal([]byte("This is a test created document that was created")))
 		})
 	})
 


### PR DESCRIPTION
Adding the Create method to the Document package to serve as the base functionality for creating a new Document in the Cosmos Database Collection